### PR TITLE
Fix typo

### DIFF
--- a/content/blog/fizzbuzz-simd-style.asciidoc
+++ b/content/blog/fizzbuzz-simd-style.asciidoc
@@ -90,7 +90,7 @@ The rules of FizzBuzz are simple:
 
 As the Vector API concerns itself with numeric values instead of strings, rather than "Fizz", "Buzz", and "FizzBuzz",
 we're going to emit -1, -2, and -3, respectively.
-The input of the program will be an array with the numbers from 0 ... 256,
+The input of the program will be an array with the numbers from 1 ... 256,
 the output an array with the FizzBuzz sequence:
 
 [source]


### PR DESCRIPTION
The output begins with `1` so the first element of the input must be `1`. Otherwise the output would be `-2, 1, 2, -1, 4, -2, -1, 7, 8, -1, -2, 11, -1, 13, 14, -3, 16, ...`